### PR TITLE
FIX: Add basic/temporary API documentation (i.e. API design and API call requests and responses) to API templates repo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,36 +89,16 @@ npm run dev:local
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 ## API design
 
-|Methods & endpoints|Description|Request body|Auth (access token)|
+|Methods & endpoints|Description|Request body||
 |--|--|:--:|:--:|
-|POST /users/signup|Create new user| email, password, passwordConfirmation, name|Not required|
-|POST /users/login|Sign in as existing user, create access token and refresh token for use in all endpoints that require access token|email, password|Access token is generated at this endpoint|
-|GET /users/sessions|Gets all users sessions made through the POST /users/login endpoint. Also reissues an access token (if access token is expired and there's refresh token) |No request body|Use access token from the POST /users/login response|
-|DELETE /users/sessions|Deletes the last recorded session created through the POST /users/login endpoint (Note: this endpoint may need fixing)|No request body|Use access token from the POST /users/login response|
-|POST /books|Create a new book (authenticated user)|title, description, pdf (file upload)|Use access token from the POST /users/login response|
-|GET /books/user/:userId|Get/view only books created by a particular user, using the user ID|No request body|Use access token from the POST /users/login response|
-|GET /books/:bookId|Get/view a book stored in the database, using the book ID|No request body|Not required (for now)|
-|PUT /books/:bookId|Update already existing book in the database, using the book ID|title, description, pdf (file upload)|Use access token from the POST /users/login response|
-|DELETE /books/:bookId|Delete a book from the database, using the book ID|No request body|Use access token from the POST /users/login response|
+|GET /demo|Gets/view all demo data| No Request Body |
+|POST /demo|Create new demo data|name, age|
+|GET /demo/:demoId|Get/view a demo data stored in the database, using the demoId|No Request Body|
+|PATCH /demo/:demoId|Update any of the properties of an already existing demo data in the database, using the demoId|propName, value|
+|PUT /demo/:id|Update all properties (at a time) of an existing demo data in the database, using the id|name, age|
+|DELETE /demo/:demoId|Deletes a demo data stored in the database, using the demoId|No request body|
 <br/>
 
 ## API call requests and responses
@@ -152,6 +132,7 @@ No request body
 }
 </pre>
 </details>
+
 
 
 <details>
@@ -246,7 +227,6 @@ e.g:
 
 
 
-
 <details>
 <summary>PUT /demo/:id</summary>
 <br/>
@@ -272,10 +252,6 @@ e.g:
 }
 </pre>
 </details>
-
-
-
-
 
 
 
@@ -307,15 +283,9 @@ No request body
 </details>
 
 
+##
 
-
-
-
-
-
-
-
-
+##
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -87,6 +87,237 @@ Start dev server for connection to local mongoDB:
 npm run dev:local
 ````
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+## API design
+
+|Methods & endpoints|Description|Request body|Auth (access token)|
+|--|--|:--:|:--:|
+|POST /users/signup|Create new user| email, password, passwordConfirmation, name|Not required|
+|POST /users/login|Sign in as existing user, create access token and refresh token for use in all endpoints that require access token|email, password|Access token is generated at this endpoint|
+|GET /users/sessions|Gets all users sessions made through the POST /users/login endpoint. Also reissues an access token (if access token is expired and there's refresh token) |No request body|Use access token from the POST /users/login response|
+|DELETE /users/sessions|Deletes the last recorded session created through the POST /users/login endpoint (Note: this endpoint may need fixing)|No request body|Use access token from the POST /users/login response|
+|POST /books|Create a new book (authenticated user)|title, description, pdf (file upload)|Use access token from the POST /users/login response|
+|GET /books/user/:userId|Get/view only books created by a particular user, using the user ID|No request body|Use access token from the POST /users/login response|
+|GET /books/:bookId|Get/view a book stored in the database, using the book ID|No request body|Not required (for now)|
+|PUT /books/:bookId|Update already existing book in the database, using the book ID|title, description, pdf (file upload)|Use access token from the POST /users/login response|
+|DELETE /books/:bookId|Delete a book from the database, using the book ID|No request body|Use access token from the POST /users/login response|
+<br/>
+
+## API call requests and responses
+
+<details>
+<summary>GET /demo</summary>
+<br/>
+    <b>Request body (sample format)</b>
+    <br/><br/>
+<pre>
+No request body
+</pre>
+<br/>
+     <b>Successful response (sample format)</b>
+    <br/><br/>
+<pre>
+{
+    "count": number,
+    "items": [
+        {
+            "_id": "string",
+            "name": "string",
+            "age": number,
+            "request": {
+                "type": "string",
+                "url": "string"
+            }
+        },
+        // etc.
+    ]
+}
+</pre>
+</details>
+
+
+<details>
+<summary>POST /demo</summary>
+<br/>
+    <b>Request body (sample format)</b>
+    <br/><br/>
+<pre>
+{
+    "name": "string",
+    "age": number
+}
+</pre>
+<br/>
+     <b>Successful response (sample format)</b>
+    <br/><br/>
+<pre>
+{
+    "message": "string",
+    "newItem": {
+        "_id": "string",
+        "name": "string",
+        "age": number,
+        "request": {
+            "type": "string",
+            "url": "string"
+        }
+    }
+}
+</pre>
+</details>
+
+
+
+<details>
+<summary>GET /demo/:demoId</summary>
+<br/>
+    <b>Request body (sample format)</b>
+    <br/><br/>
+<pre>
+No request body
+</pre>
+<br/>
+     <b>Successful response (sample format)</b>
+    <br/><br/>
+<pre>
+{
+    "_id": "string",
+    "name": "string",
+    "age": number,
+    "request": {
+        "type": "string",
+        "description": "string",
+        "url": "string"
+    }
+}
+</pre>
+</details>
+
+
+
+<details>
+<summary>PATCH /demo/:demoId</summary>
+<br/>
+    <b>Request body (sample format)</b>
+    <br/><br/>
+<pre>
+[
+    {"string (PROPERTY-NAME)": "string (VALUE)"},
+    // etc.
+]
+e.g:
+[
+    {"name": "string"},
+    {"age": "number"}
+]
+</pre>
+<br/>
+     <b>Successful response (sample format)</b>
+    <br/><br/>
+<pre>
+{
+    "message": "string",
+    "request": {
+        "type": "string",
+        "description": "string",
+        "url": "string"
+    }
+}
+</pre>
+</details>
+
+
+
+
+<details>
+<summary>PUT /demo/:id</summary>
+<br/>
+    <b>Request body (sample format)</b>
+    <br/><br/>
+<pre>
+{
+    "name": "string",
+    "age": number
+}
+</pre>
+<br/>
+     <b>Successful response (sample format)</b>
+    <br/><br/>
+<pre>
+{
+    "message": "string",
+    "request": {
+        "type": "string",
+        "description": "string",
+        "url": "string"
+    }
+}
+</pre>
+</details>
+
+
+
+
+
+
+
+<details>
+<summary>DELETE /demo/:demoId</summary>
+<br/>
+    <b>Request body (sample format)</b>
+    <br/><br/>
+<pre>
+No request body
+</pre>
+<br/>
+     <b>Successful response (sample format)</b>
+    <br/><br/>
+<pre>
+{
+    "message": "string",
+    "request": {
+        "type": "string",
+        "description": "string",
+        "url": "string",
+        "body": {
+            "name": "string",
+            "age": "string"
+        }
+    }
+}
+</pre>
+</details>
+
+
+
+
+
+
+
+
+
+
+
+
+
 ## Documentation
 See the links to the official documentation of the node-mongo project and community building it below:
 - [Node Mongo documentation](https://code-collabo.gitbook.io/node-mongo-v2.0.0)


### PR DESCRIPTION
**This pull request makes the following changes**
* Fixes code-collabo/node-mongo#35

**General checklist**
- [x] File or folder now contains changes as specified in the issue i worked on
- [x] I have linked the issue I worked on to this pull request submitted by me

**Testing checklist**
- [x] The readme of the API boilerplates repo now contains the temporary documentation API design and API call requests and responses
- [x] The temporary API doc is added just before the Documentation section of the API boilerplates repo's readme
- [x] The temporary API doc is written accordingly and correctly for all methods (GET, POST etc) and the /demo (and demo id) endpoints that exist in the API
- [x] The same formatting, headers, tables, dropdowns, code blocks etc from the buuks repo example is used
- [x] I certify that I ran my checklist

Ping @code-collabo/node-mongo-api-boilerplate-templates
