### PR TITLE
PR for fixing export issue from the node-mongo-helpers.js file in cjs template

### DIFF
--- a/cjs/node-mongo-helpers.js
+++ b/cjs/node-mongo-helpers.js
@@ -17,12 +17,6 @@ const error = (message) => {
   console.log( chalk.redBright(message) );
 }
 
-module.exports = {
-  success,
-  warning,
-  error
-};
-
 // DB connect
 const watchEslint = () => {
   const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
@@ -58,7 +52,12 @@ const connectToDBunsuccessful = (err) => {
   warning('Refer to the node-mongo documentation: https://code-collabo.gitbook.io/node-mongo-v2.0.0\n\nGet further help from Code Collabo Community\'s Node mongo channel: https://matrix.to/#/#collabo-node-mongo:gitter.im\n');
 }
 
+
+// export all helper functions together
 module.exports = {
+  success,
+  warning,
+  error,
   watchEslint,
   server,
   afterAtlasDBconnectSuccessful,

--- a/cjs/src/api/controllers/demo.controller.js
+++ b/cjs/src/api/controllers/demo.controller.js
@@ -6,7 +6,7 @@ const {
   updateOneDemoItemPropertyValueService,
   updateDemoItemPropertyValuesService,
 } = require('../services/demo.service');
-const {success, error} = require('../../../node-mongo-helpers');
+const { success, error } = require('../../../node-mongo-helpers');
 
 const routeName = 'demo';
 const item = `${routeName}-item`;

--- a/cjs/src/api/controllers/demo.controller.js
+++ b/cjs/src/api/controllers/demo.controller.js
@@ -6,7 +6,7 @@ const {
   updateOneDemoItemPropertyValueService,
   updateDemoItemPropertyValuesService,
 } = require('../services/demo.service');
-const { success, error } = require('../../../node-mongo-helpers');
+const {success, error} = require('../../../node-mongo-helpers');
 
 const routeName = 'demo';
 const item = `${routeName}-item`;


### PR DESCRIPTION
**This pull request makes the following changes**
* Fixes code-collabo/node-mongo-api-boilerplate-templates

while testing the cjs template, I encountered an error importing the node-helper functions {success, error} in the demo controller file.

```
/........./web-dev/code-collabo/node-mongo-api-boilerplate-templates/cjs/src/api/controllers/demo.controller.js:95
    error(`Error retriving ${item}: ${err}`);
    ^
TypeError: error is not a function
    at /home/samuko/web-dev/code-collabo/node-mongo-api-boilerplate-templates/cjs/src/api/controllers/demo.controller.js:95:5
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

 I believe separating exports in the cjs/node-mongo-helpers.js file caused it.
I solved it by exporting all the functions in the cjs/node-mongo-helpers.js file together.

Ping @code-collabo/node-mongo-api-boilerplate-templates
