### PR TITLE
Change Commands Used To Start local and atlas Connections

### DIFF
--- a/cjs/package.json
+++ b/cjs/package.json
@@ -5,8 +5,8 @@
   "main": "src/server.[atlas/local].js",
   "scripts": {
     "dev": "node -r esm node-mongo.js",
-    "dev:local": "nodemon --exec node src/server.local.js",
-    "dev:atlas": "nodemon --exec node src/server.atlas.js",
+    "dev:local": "node -r esm node-mongo.js node src/server.local.js",
+    "dev:atlas": "node -r esm node-mongo.js node src/server.atlas.js",
     "lint": "esw src --color",
     "lint:watch": "npm run lint -- --watch",
     "dev:restore": "node -r esm node-mongo.js",

--- a/esm/package.json
+++ b/esm/package.json
@@ -5,8 +5,8 @@
   "main": "src/server.[atlas/local].js",
   "scripts": {
     "dev": "node -r esm node-mongo.js",
-    "dev:local": "nodemon --exec babel-node src/server.local.js",
-    "dev:atlas": "nodemon --exec babel-node src/server.atlas.js",
+    "dev:local": "node -r esm node-mongo.js babel-node src/server.local.js",
+    "dev:atlas": "node -r esm node-mongo.js babel-node src/server.atlas.js",
     "lint": "esw src --color",
     "lint:watch": "npm run lint -- --watch",
     "dev:restore": "node -r esm node-mongo.js",

--- a/ts/package.json
+++ b/ts/package.json
@@ -5,8 +5,8 @@
   "main": "src/server.[atlas/local].ts",
   "scripts": {
     "dev": "node -r esm node-mongo.js",
-    "dev:local": "nodemon --exec ts-node src/server.local.ts",
-    "dev:atlas": "nodemon --exec ts-node src/server.atlas.ts",
+    "dev:local": "node -r esm node-mongo.js ts-node src/server.local.ts",
+    "dev:atlas": "node -r esm node-mongo.js ts-node src/server.atlas.ts",
     "lint": "esw src --ext .ts --color",
     "lint:watch": "npm run lint -- --watch",
     "dev:restore": "node -r esm node-mongo.js",


### PR DESCRIPTION
**This pull request makes the following changes**
* Fixes code-collabo/node-mongo/issues/54

**General checklist**
- [x] File or folder now contains changes as specified in the issue I worked on
- [x] I have linked the issue I worked on to this pull request submitted by me

**Testing checklist**
- [x] When user is still in atlas mode: User has been informed that they can only use or access the `dev:local` script command when they have switched to local connection setup type via the `npm:change` script command
- [x] When user is still in local mode: User has been informed that they can only use or access the `dev:atlas` script command when they have switched to ATLAS connection setup type via the `npm:change` script command
- [x] I certify that I ran my checklist

![image](https://github.com/code-collabo/node-mongo-api-boilerplate-templates/assets/42407804/e7f8c2ed-25fa-4d09-987a-975ca67dbe14)

Ping @code-collabo/node-mongo-api-boilerplate-templates
